### PR TITLE
adding deprication warning display to unit test runs

### DIFF
--- a/examples/django-test-publish/cicd.yml
+++ b/examples/django-test-publish/cicd.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m compileall ${APP_NAME}/
-          coverage run --source=${APP_NAME}/ manage.py test ${APP_NAME}
+          python -Wd -m coverage run --source=${APP_NAME}/ manage.py test ${APP_NAME}
 
       - name: Report Test Coverage
         if: matrix.django-version == env.COVERAGE_DJANGO_VERSION

--- a/examples/python-test-publish/cicd.yml
+++ b/examples/python-test-publish/cicd.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m compileall ${APP_NAME}/
-          coverage run ${APP_NAME}/test.py -v
+          python -Wd -m coverage run ${APP_NAME}/test.py -v
 
       - name: Report Test Coverage
         env:


### PR DESCRIPTION
This adds the flags to python-test-publish and django-test-publish examples. Looking at the django-build-test-deploy example that calls the app's docker/test.sh file to run tests, so this flag would need to be set there for apps.