### PR TITLE
Switch Trivy to immutable release

### DIFF
--- a/container-vuln-scan/action.yml
+++ b/container-vuln-scan/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Run Trivy vulnerability scanner (with ignorefile)
       if: steps.check-ignorefile.outputs.use_ignorefile == 'true'
       id: scan-with-ignore
-      uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: ${{ inputs.image_tag }}
         severity: ${{ inputs.severity }}
@@ -76,7 +76,7 @@ runs:
     - name: Run Trivy vulnerability scanner (without ignorefile)
       if: steps.check-ignorefile.outputs.use_ignorefile == 'false'
       id: scan-without-ignore
-      uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: ${{ inputs.image_tag }}
         severity: ${{ inputs.severity }}


### PR DESCRIPTION
Trivy v0.35.0+ uses immutable releases.